### PR TITLE
Add share link feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "helmet": "^8.1.0",
         "jquery": "^4.0.0",
         "lodash": "^4.18.1",
+        "lz-string": "^1.5.0",
         "monaco-editor": "^0.55.1",
         "monaco-editor-webpack-plugin": "^7.1.1",
         "morgan": "^1.10.1",
@@ -2057,6 +2058,15 @@
       },
       "engines": {
         "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/marked": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "helmet": "^8.1.0",
     "jquery": "^4.0.0",
     "lodash": "^4.18.1",
+    "lz-string": "^1.5.0",
     "monaco-editor": "^0.55.1",
     "monaco-editor-webpack-plugin": "^7.1.1",
     "morgan": "^1.10.1",

--- a/source/compiler.js
+++ b/source/compiler.js
@@ -20,6 +20,11 @@ export default function CompilerComponent(container, state) {
         this.onCompiled(results);
     }, this));
 
+    if (this.session.initialOptions) {
+        this.optionsField.val(this.session.initialOptions);
+        this.session.options = this.session.initialOptions;
+    }
+
     const optionsChange = _.debounce(e => {
         this.session.notifyOptions($(e.target).val());
     }, 800);

--- a/source/editor.js
+++ b/source/editor.js
@@ -53,19 +53,44 @@ export default function EditorComponent(container, state) {
     }, this));
 
     var shareBtn = $('#shareBtn');
+    var shareModal = $('#shareModal');
+    var shareLink = $('#shareLink');
+    var copyLinkBtn = $('#copyLinkBtn');
+    var closeModalBtn = $('#closeModalBtn');
+    var shareModalClose = $('.share-modal-close');
+
     shareBtn.on('click', _.bind(function () {
         var state = this.session.getCurrentState();
         setStateInHash(state.source, state.options);
         var url = window.location.href;
-        navigator.clipboard.writeText(url).then(() => {
-            shareBtn.text('Copied!');
+        shareLink.val(url);
+        shareModal.addClass('show');
+    }, this));
+
+    copyLinkBtn.on('click', function () {
+        shareLink.select();
+        navigator.clipboard.writeText(shareLink.val()).then(() => {
+            copyLinkBtn.text('Copied!');
             setTimeout(() => {
-                shareBtn.text('Share');
+                copyLinkBtn.text('Copy Link');
             }, 2000);
         }).catch(() => {
-            alert('Link updated in URL. Copy from address bar:\n' + url);
+            alert('Could not copy. Please copy manually:\n' + shareLink.val());
         });
-    }, this));
+    });
+
+    var closeModal = function () {
+        shareModal.removeClass('show');
+        copyLinkBtn.text('Copy Link');
+    };
+
+    closeModalBtn.on('click', closeModal);
+    shareModalClose.on('click', closeModal);
+    shareModal.on('click', function (e) {
+        if (e.target === shareModal[0]) {
+            closeModal();
+        }
+    });
 
     container.on('resize', this.updateEditorLayout);
     container.on('shown', this.updateEditorLayout);

--- a/source/editor.js
+++ b/source/editor.js
@@ -1,5 +1,6 @@
 import * as monaco from 'monaco-editor';
 import _ from 'underscore';
+import { setStateInHash } from './urlState.js';
 
 export default function EditorComponent(container, state) {
     this.container = container;
@@ -31,6 +32,11 @@ export default function EditorComponent(container, state) {
         theme: 'vs-dark'
     });
 
+    if (this.session.initialSource !== null) {
+        this.editor.getModel().setValue(this.session.initialSource);
+        this.session.source = this.session.initialSource;
+    }
+
     this.updateEditorLayout = _.bind(function () {
         var topBarHeight = this.domRoot.find(".top-bar").outerHeight(true) || 0;
         this.editor.layout({width: this.domRoot.width(), height: this.domRoot.height() - topBarHeight});
@@ -44,6 +50,21 @@ export default function EditorComponent(container, state) {
 
     this.editor.getModel().onDidChangeContent(_.bind(function () {
         this.debouncedEmitChange();
+    }, this));
+
+    var shareBtn = $('#shareBtn');
+    shareBtn.on('click', _.bind(function () {
+        var state = this.session.getCurrentState();
+        setStateInHash(state.source, state.options);
+        var url = window.location.href;
+        navigator.clipboard.writeText(url).then(() => {
+            shareBtn.text('Copied!');
+            setTimeout(() => {
+                shareBtn.text('Share');
+            }, 2000);
+        }).catch(() => {
+            alert('Link updated in URL. Copy from address bar:\n' + url);
+        });
     }, this));
 
     container.on('resize', this.updateEditorLayout);

--- a/source/main.css
+++ b/source/main.css
@@ -87,3 +87,23 @@ input, input:focus {
 .top-bar.btn-toolbar.bg-light {
     border-bottom: 1px solid #202122;
 }
+
+.top-bar.btn-toolbar {
+    display: flex !important;
+    justify-content: flex-end;
+    align-items: center;
+    padding: 0.5rem;
+}
+
+#shareBtn {
+    margin: 0;
+}
+
+.navbar-nav.navbar-right {
+    float: right;
+    margin-right: 15px;
+}
+
+.navbar-nav.navbar-right #shareBtn {
+    margin-top: 8px;
+}

--- a/source/main.css
+++ b/source/main.css
@@ -107,3 +107,110 @@ input, input:focus {
 .navbar-nav.navbar-right #shareBtn {
     margin-top: 8px;
 }
+
+.share-modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.7);
+    z-index: 9999;
+    align-items: center;
+    justify-content: center;
+}
+
+.share-modal.show {
+    display: flex;
+}
+
+.share-modal-content {
+    background-color: #2d2d2d;
+    border: 1px solid #474747;
+    border-radius: 4px;
+    width: 90%;
+    max-width: 500px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+}
+
+.share-modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem;
+    border-bottom: 1px solid #474747;
+}
+
+.share-modal-header h4 {
+    margin: 0;
+    color: #f2f2f2;
+    font-size: 1.2rem;
+}
+
+.share-modal-close {
+    background: none;
+    border: none;
+    color: #f2f2f2;
+    font-size: 1.5rem;
+    cursor: pointer;
+    padding: 0;
+    width: 30px;
+    height: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.share-modal-close:hover {
+    color: #45bbe0;
+}
+
+.share-modal-body {
+    padding: 1.5rem;
+}
+
+.share-modal-body p {
+    color: #eee;
+    margin: 0 0 1rem 0;
+    font-size: 0.95rem;
+}
+
+.share-link-container {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+.share-link-input {
+    flex: 1;
+    padding: 0.5rem;
+    background-color: #1e1e1e !important;
+    color: #eee !important;
+    border: 1px solid #474747 !important;
+    border-radius: 4px;
+    font-size: 0.85rem;
+    font-family: monospace;
+}
+
+.share-link-input:focus {
+    outline: none;
+    border: 1px solid #45bbe0 !important;
+    box-shadow: 0 0 4px rgba(69, 187, 224, 0.3);
+}
+
+.share-modal-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    padding: 1rem;
+    border-top: 1px solid #474747;
+}
+
+#copyLinkBtn {
+    margin: 0 !important;
+}
+
+#closeModalBtn {
+    margin: 0 !important;
+}

--- a/source/main.js
+++ b/source/main.js
@@ -4,11 +4,18 @@ import { GoldenLayout, ItemType } from 'golden-layout';
 import CompilerComponent from './compiler.js';
 import EditorComponent from './editor.js';
 import CodeSession from './session.js';
+import { getStateFromHash } from './urlState.js';
 
 require("!style-loader!css-loader!./main.css")
 
 function start() {
     var session = new CodeSession(1);
+    
+    var urlState = getStateFromHash();
+    if (urlState) {
+        session.setInitialState(urlState.source || '', urlState.options || '');
+    }
+    
     var defaultConfig = {
         root: {
             type: 'row',

--- a/source/session.js
+++ b/source/session.js
@@ -4,6 +4,8 @@ export default function CodeSession(id) {
     this.id = id;
     this.source = null;
     this.options = '';
+    this.initialSource = null;
+    this.initialOptions = '';
     this.codeEditCallbacks = $.Callbacks('unique');
     this.codeCompileCallbacks = $.Callbacks('unique');
 }
@@ -14,6 +16,18 @@ CodeSession.prototype.onCodeEdited = function (fn) {
 
 CodeSession.prototype.onCodeCompiled = function (fn) {
     this.codeCompileCallbacks.add(fn);
+}
+
+CodeSession.prototype.setInitialState = function (source, options) {
+    this.initialSource = source;
+    this.initialOptions = options;
+}
+
+CodeSession.prototype.getCurrentState = function () {
+    return {
+        source: this.source,
+        options: this.options
+    };
 }
 
 CodeSession.prototype.sendCompileRequest = function (source, options) {

--- a/source/urlState.js
+++ b/source/urlState.js
@@ -1,0 +1,29 @@
+import LZ from 'lz-string';
+
+export function encodeState(source, options) {
+    const state = { source, options };
+    const json = JSON.stringify(state);
+    return LZ.compressToBase64(json);
+}
+
+export function decodeState(encoded) {
+    try {
+        const json = LZ.decompressFromBase64(encoded);
+        if (!json) return null;
+        const state = JSON.parse(json);
+        return state;
+    } catch (e) {
+        return null;
+    }
+}
+
+export function getStateFromHash() {
+    const hash = window.location.hash.slice(1);
+    if (!hash) return null;
+    return decodeState(hash);
+}
+
+export function setStateInHash(source, options) {
+    const encoded = encodeState(source, options);
+    window.location.hash = encoded;
+}

--- a/views/index.pug
+++ b/views/index.pug
@@ -14,6 +14,19 @@ html(lang="en")
 
     #root
 
+    #shareModal.share-modal
+      .share-modal-content
+        .share-modal-header
+          h4 Share Slang Code
+          button.share-modal-close(type="button" title="Close") ×
+        .share-modal-body
+          p Copy this link to share your code:
+          .share-link-container
+            input#shareLink.share-link-input(type="text" readonly)
+            button#copyLinkBtn.btn.btn-sm.btn-primary Copy Link
+        .share-modal-footer
+          button#closeModalBtn.btn.btn-sm.btn-secondary Close
+
     .gl_keep.template
       #codeEditor
         .top-bar.btn-toolbar(role="toolbar")

--- a/views/index.pug
+++ b/views/index.pug
@@ -2,19 +2,22 @@ doctype html
 html(lang="en")
   head
     include head.pug
+    link(rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='75' font-size='75' fill='%23007bff'>S</text></svg>")
 
   body
     .navbar
       .container-fluid
         .navbar-header
           a.navbar-brand(href='#' title='slang explorer') slang explorer
+        .navbar-nav.navbar-right
+          button#shareBtn.btn.btn-sm.btn-primary(title="Copy shareable link to clipboard") Share
 
     #root
 
     .gl_keep.template
       #codeEditor
         .top-bar.btn-toolbar(role="toolbar")
-        .monaco-placeholder
+          .monaco-placeholder
 
       #compiler
         .top-bar.btn-toolbar.options-toolbar.bg-light(role="toolbar")


### PR DESCRIPTION
Adds support for sharing the current editor state using a URL.

- Encodes code and compiler options into the URL
- Restores state when the link is opened
- Adds a share button with a modal to copy the link
- Uses LZ-string for compression

Testing
- Tested with sample code
- Tested sharing across browsers (one browser to another)

**Share Button**
<img width="1433" height="140" alt="Screenshot 2026-04-19 at 12 32 50 PM" src="https://github.com/user-attachments/assets/ae498e0a-bc56-4e7e-972c-428f7a9b561b" />

**Share Button**
<img width="604" height="343" alt="Screenshot 2026-04-19 at 12 33 08 PM" src="https://github.com/user-attachments/assets/ccb16a96-5230-4454-9310-1b4bcd0b9e31" />


