### PR TITLE
Fix : run compiler automatically when loading from shared link

### DIFF
--- a/source/main.js
+++ b/source/main.js
@@ -46,6 +46,10 @@ function start() {
 
     layout.loadLayout(defaultConfig);
 
+    if (urlState) {
+        session.sendCompileRequest(urlState.source || '', urlState.options || '');
+    }
+
     function sizeRoot() {
         var height = $(window).height() - rootElement.position().top;
         rootElement.height(height);


### PR DESCRIPTION
Fixes an issue where the compiler does not run when opening a shared link.
Now the compiler automatically runs after restoring the editor state from the URL.

Testing
- Tested with sample shared links
- Verified in different browsers