### PR TITLE
handle ANSI codes in compiler output

### DIFF
--- a/source/editor.js
+++ b/source/editor.js
@@ -103,9 +103,19 @@ EditorComponent.prototype.getSource = function () {
     return this.editor.getModel().getValue();
 };
 
+function stringToMonacoSeverity(severity) {
+    const severityMap = {
+        'error': 8,
+        'warning': 4,
+        'info': 2,
+        'note': 1
+    };
+    return severityMap[severity.toLowerCase()] || 4;
+}
+
 EditorComponent.prototype.handleCompileResults = function (results) {
     const markers = results.diags.map(d => ({
-        severity: d.severity,
+        severity: stringToMonacoSeverity(d.severity),
         startLineNumber: d.line,
         startColumn: d.col,
         endLineNumber: d.line,

--- a/source/main.js
+++ b/source/main.js
@@ -46,6 +46,10 @@ function start() {
 
     layout.loadLayout(defaultConfig);
 
+    if (urlState) {
+        session.sendCompileRequest(urlState.source || '', urlState.options || '');
+    }
+
     function sizeRoot() {
         var height = $(window).height() - rootElement.position().top;
         rootElement.height(height);

--- a/source/session.js
+++ b/source/session.js
@@ -73,7 +73,10 @@ CodeSession.prototype.handleResult = function (result) {
     var diags = []
     var lines = splitLines(raw);
 
-    var chunks = raw.split(/source.sv:(\d+):(\d+): (\w+): (.*)\r?\n/);
+    // Strip ANSI codes to handle both local and production formats
+    var cleanRaw = raw.replace(/\u001b\[\d+m/g, '');
+
+    var chunks = cleanRaw.split(/source.sv:(\d+):(\d+): (\w+): (.*)\r?\n/);
     var i = 0;
     if (chunks.length > 0)
         i += 1;

--- a/source/session.js
+++ b/source/session.js
@@ -69,7 +69,7 @@ function splitLines(text) {
 }
 
 CodeSession.prototype.handleResult = function (result) {
-    var raw = result.stdout || ''
+    var raw = result.stderr || result.stdout || ''
     var diags = []
     var lines = splitLines(raw);
 


### PR DESCRIPTION
<img width="1440" height="433" alt="Screenshot 2026-05-04 at 6 09 00 PM" src="https://github.com/user-attachments/assets/3815f5f6-c8e0-4a38-a0a8-5e9e2f7b1e47" />


Hi @MikePopoloski,

I checked further and found that in production the compiler output includes ANSI codes and comes through stdout, which was causing the parsing issue.
I’ve added a small fix to strip ANSI codes and tested it locally with both formats. It passes my test cases.
Could we try this on production and see if it works there?