### PR TITLE
handle ANSI codes in compiler output

### DIFF
--- a/source/session.js
+++ b/source/session.js
@@ -73,7 +73,10 @@ CodeSession.prototype.handleResult = function (result) {
     var diags = []
     var lines = splitLines(raw);
 
-    var chunks = raw.split(/source.sv:(\d+):(\d+): (\w+): (.*)\r?\n/);
+    // Strip ANSI codes to handle both local and production formats
+    var cleanRaw = raw.replace(/\u001b\[\d+m/g, '');
+
+    var chunks = cleanRaw.split(/source.sv:(\d+):(\d+): (\w+): (.*)\r?\n/);
     var i = 0;
     if (chunks.length > 0)
         i += 1;


### PR DESCRIPTION

<img width="1440" height="433" alt="Screenshot 2026-05-04 at 6 09 00 PM" src="https://github.com/user-attachments/assets/87f5941b-7c8e-490c-860d-a456dfdb2f3a" />

Hi @MikePopoloski,

I checked further and found that in production the compiler output includes ANSI codes and comes through stdout, which was causing the parsing issue.
I’ve added a small fix to strip ANSI codes and tested it locally with both formats. It passes my test cases.
Could we try this on production and see if it works there?